### PR TITLE
Correctly use the component prop passed in to wrap the selectable items

### DIFF
--- a/dist/react-selectable-extended.js
+++ b/dist/react-selectable-extended.js
@@ -535,8 +535,10 @@ return /******/ (function(modules) { // webpackBootstrap
 				    fixedPosition = _props3.fixedPosition,
 				    remainingProps = _objectWithoutProperties(_props3, ['selectedItems', 'onSelection', 'duringSelection', 'dontClearSelection', 'component', 'tolerance', 'fixedPosition']);
 
+				var SelectableComponentWrapper = component;
+
 				return _react2.default.createElement(
-					'component',
+					SelectableComponentWrapper,
 					remainingProps,
 					this.state.isBoxSelecting && _react2.default.createElement(
 						'div',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-selectable-extended",
-  "version": "0.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "dist/react-selectable-extended.js",
   "repository": {

--- a/src/selectable-group.js
+++ b/src/selectable-group.js
@@ -371,13 +371,15 @@ class SelectableGroup extends React.Component {
 			...remainingProps,
 		} = this.props;
 
+		const SelectableComponentWrapper = component;
+
 		return (
-			<component {...remainingProps}>
+			<SelectableComponentWrapper {...remainingProps}>
 				{this.state.isBoxSelecting &&
 				  <div style={boxStyle} ref="selectbox"><span style={spanStyle}></span></div>
 				}
 				{this.props.children}
-			</component>
+			</SelectableComponentWrapper>
 		);
 	}
 }


### PR DESCRIPTION
When using the latest version of the package I was seeing errors like this in the console:
![screen shot 2018-05-14 at 12 12 36 pm](https://user-images.githubusercontent.com/12392541/39975135-1f1a9bec-5770-11e8-853a-91946fde9bb2.png)

It's because when this package was using `<component />` React was trying to render a html element called component, it was not trying to use the `component` prop passed in. 

This PR updates the code to convert the `component` prop into a variable that React can correctly render.